### PR TITLE
bugfix/Termination signal handling for Gin

### DIFF
--- a/cmd/kdd.go
+++ b/cmd/kdd.go
@@ -108,10 +108,15 @@ func main() {
 		Handler:        router.InitRouter(ds, services.NewKubeAPIAdapter(&services.KubeAPIAdapterConfig{ClientSet: buildClientSet()})),
 	}
 
-	err = server.ListenAndServe()
-	if errors.Is(err, http.ErrServerClosed) {
-		zap.L().Info("server closed")
-	} else if err != nil {
-		zap.L().Fatal("error starting server", zap.Error(err))
-	}
+	go func() {
+		err = server.ListenAndServe()
+		if errors.Is(err, http.ErrServerClosed) {
+			zap.L().Info("server closed")
+		} else if err != nil {
+			zap.L().Fatal("error starting server", zap.Error(err))
+		}
+	}()
+
+	<-sigReceiver // wait for the termination signal
+
 }


### PR DESCRIPTION
Gin server was not running in goroutine, and was not killed after termination signal was recieved. This caused kdd to hang after Ctrl+C (workloads were not collected, gin server was still running).